### PR TITLE
Fix: Improve text contrast in light theme dropdown

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -506,12 +506,16 @@ header {
     text-align: left;
     width: 100%;
     transition: all 0.2s ease;
+    color: #222;
+    text-shadow: none;
   }
 
   .mobile-settings-panel .icon-button:hover {
     background: linear-gradient(135deg, rgba(255,255,255,0.3) 0%, rgba(255,255,255,0.2) 100%);
     transform: none;
   }
+
+  .mobile-settings-panel .lang-btn { color: #222; }
 
   .mobile-settings-panel .icon-button::after {
     content: attr(data-label);


### PR DESCRIPTION
### Purpose
Based on the conversation, the user identified a readability issue in the settings dropdown when using the light theme. The primary goal was to adjust the text color to provide better contrast and improve user experience.

### Code changes
- The CSS was updated to set the text `color` to `#222` for elements within the `.mobile-settings-panel`.
- The `text-shadow` was removed to enhance clarity.
- A specific rule was added to ensure the language button (`.lang-btn`) also adopts the new, more readable text color.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/aead506179024895a6c6b2fdc7d4f1a0/curry-studio)

👀 [Preview Link](https://aead506179024895a6c6b2fdc7d4f1a0-curry-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>aead506179024895a6c6b2fdc7d4f1a0</projectId>-->
<!--<branchName>curry-studio</branchName>-->